### PR TITLE
fix: show Book Now button on mobile in header and contacts section

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -1594,4 +1594,27 @@ img {
         margin: 0 auto
     }
 }
+/* === Mobile fixes === */
+
+/* Show BOOK NOW in header on mobile (before hamburger) */
+@media screen and (max-width:991.97px) {
+    .header_btn {
+        display: block;
+        order: 2;
+        margin-left: auto;
+        margin-right: 16px;
+        padding: 8px 14px;
+        font-size: 0.75rem;
+    }
+    .header_trigger {
+        order: 3;
+    }
+}
+
+/* Show BOOK NOW in contacts section on all screen sizes */
+#contacts .header_btn {
+    display: block;
+    margin-left: 0;
+}
+
 /*# sourceMappingURL=../sourcemaps/index.css.map */


### PR DESCRIPTION
Fixes missing BOOK NOW button on mobile devices in header and contacts section. Root cause: .header_btn class was display:none by default, only shown at 992px+. Added mobile CSS overrides.